### PR TITLE
Add loader for loading file and invalid file

### DIFF
--- a/tensormap-client/src/pages/visualizedata/VisualizeData.jsx
+++ b/tensormap-client/src/pages/visualizedata/VisualizeData.jsx
@@ -18,6 +18,7 @@ import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
 import Search from '@material-ui/icons/Search';
 import ViewColumn from '@material-ui/icons/ViewColumn';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import { saveAs } from 'file-saver';
 import { forwardRef } from 'react';
 import { template } from '@babel/core';
@@ -418,8 +419,24 @@ class VisualizeData extends React.Component {
     const {sampleData} = this.state;
     const {classes} = this.props;
     const {match} = this.props;
+    let loadingMessage = null;
 
-    
+    const isLoadingData = () => {
+      if (this.props.data && this.props.fileName) {
+        console.log("Data loaded!")
+        return false;
+      } else if (!this.props.fileName) {
+        console.log("Unable to find file.")
+        loadingMessage = "Cannot find file";
+        setTimeout(() => {
+          loadingMessage += " You might want to check your query or file name."
+        }, 8000);
+        return true;
+      } else {
+        loadingMessage = "Data is loading";
+        return true;
+      }
+    }
 
     return (
       <div className={classes.container}>
@@ -482,51 +499,60 @@ class VisualizeData extends React.Component {
         </div>
 
         <div style={{ maxWidth: "100%" }}>
-        <MaterialTable
-        icons={tableIcons}
-      title={this.state.fileName}
-      columns={this.state.columns}
-      data={this.state.data}
-      options={{
-        filtering: true
-      }}
-      editable={{
-        onRowAdd: newData =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve();
-              const tempdata = [...this.state.data];
-              tempdata.push(newData);
-              this.setState({data:tempdata});
-              console.log(newData);
-              this.sendAddRequest(newData);
-            }, 600);
-          }),
-        onRowDelete: oldData =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve();
-              console.log(oldData)
-              const tempdata = [...this.state.data];
-              tempdata.splice(tempdata.indexOf(oldData), 1);
-              this.setState({data:tempdata});
-              console.log(oldData);
-              this.sendDeleteRequest(oldData);
-            }, 600);
-          }),
-          onRowUpdate: (newData, oldData) =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve();
-              const tempdata = [...this.state.data];
-              tempdata[tempdata.indexOf(oldData)] = newData;
-              this.setState({data:tempdata});
-              console.log(oldData);
-              console.log(newData);
-              this.sendEditRequest(newData);
-            }, 600);
-          }),
-      }} />
+          {   
+          () => isLoadingData() ? 
+            <div>
+              <h2> {loadingMessage}... </h2>
+              <LinearProgress color="secondary" />
+            </div>
+              :
+            <MaterialTable
+            icons={tableIcons}
+            title={this.state.fileName}
+            columns={this.state.columns}
+            data={this.state.data}
+            options={{
+            filtering: true
+            }}
+            editable={{
+            onRowAdd: newData =>
+              new Promise(resolve => {
+                setTimeout(() => {
+                  resolve();
+                  const tempdata = [...this.state.data];
+                  tempdata.push(newData);
+                  this.setState({data:tempdata});
+                  console.log(newData);
+                  this.sendAddRequest(newData);
+                }, 600);
+              }),
+            onRowDelete: oldData =>
+              new Promise(resolve => {
+                setTimeout(() => {
+                  resolve();
+                  console.log(oldData)
+                  const tempdata = [...this.state.data];
+                  tempdata.splice(tempdata.indexOf(oldData), 1);
+                  this.setState({data:tempdata});
+                  console.log(oldData);
+                  this.sendDeleteRequest(oldData);
+                }, 600);
+              }),
+              onRowUpdate: (newData, oldData) =>
+              new Promise(resolve => {
+                setTimeout(() => {
+                  resolve();
+                  const tempdata = [...this.state.data];
+                  tempdata[tempdata.indexOf(oldData)] = newData;
+                  this.setState({data:tempdata});
+                  console.log(oldData);
+                  console.log(newData);
+                  this.sendEditRequest(newData);
+                }, 600);
+              }),
+            }} />
+          } 
+       
         </div>
       </div>
     )

--- a/tensormap-server/app/resources/user_template/user_keras_temp.py
+++ b/tensormap-server/app/resources/user_template/user_keras_temp.py
@@ -1,0 +1,40 @@
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+import numpy as np
+from sklearn.metrics import mean_squared_error, mean_absolute_error
+from sklearn.model_selection import train_test_split
+import pandas as pd
+
+np.random.seed(0)
+
+dataCsv = pd.read_csv()
+        
+_x = dataCsv[]
+_y = dataCsv[]
+
+x_train, y_train, x_test, y_test = train_test_split(_x, _y, random_state=42, shuffle=True, test_size=)
+
+network = tf.keras.models.Sequential(name='userModel')
+
+network.compile (optimizer = ,loss = )
+
+mod_history = network.fit (x_train, y_train, epochs=, verbose=1, batch_size=)
+
+test_loss, = network.evaluate(x_test, y_test)
+
+predictions = network.predict(x_test, verbose=1)
+
+mse = mean_squared_error(test_labels, prediction)
+rmse = sqrt(meanSquaredError)
+mae = mean_absolute_error(test_labels, prediction)
+
+print("MSE: ",mse)
+print("RMSE: ",rmse)
+print("MAE: ",mae)
+
+with open("results.csv", "w") as f:
+    writer = csv.writer(f)
+    writer.writerows(zip(y_test,predictions))
+
+


### PR DESCRIPTION
Solution improved upon. Uses a `isLoadingData()` helper function to determine what to show in place of the content of the page. Handles invalid file names (assuming the page does not error due to not finding certain property.

Upon data being loaded (indicated by the lack of the data prop, initialized to an empty array), we will display a linear loader and a message relating to the state of the page.

