### PR TITLE
fix uploaded dataset name issue

### DIFF
--- a/tensormap-client/src/pages/viewdata/assets/Table.jsx
+++ b/tensormap-client/src/pages/viewdata/assets/Table.jsx
@@ -204,7 +204,7 @@ class EnhancedTable extends React.Component {
 
     var data__ = [];
     this.props.data.forEach((x) => {
-      data__.push(createData(x.id,x.name,x.fileFormat))
+      data__.push(createData(x.id,x.fileName,x.fileFormat))
     })
 
     this.setState({


### PR DESCRIPTION
Fixes: #99 
**Current Behaviour:** Currently when we upload a dataset, it's name is not showing up on the uploaded dataset panel.

**Expected Behaviour:** The uploaded dataset should appear with its name

**Screenshots:**
![image](https://user-images.githubusercontent.com/31389740/75255898-adf94a80-5808-11ea-81b0-c1c48380668a.png)
