### PR TITLE
two output nodes give error

### DIFF
--- a/tensormap-client/src/pages/dashboard/scenes/a/components/assets/BodyWidget.tsx
+++ b/tensormap-client/src/pages/dashboard/scenes/a/components/assets/BodyWidget.tsx
@@ -468,6 +468,9 @@ class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState> {
                                   event => {
                                     var data = JSON.parse(event.dataTransfer.getData("storm-diagram-node"));
                                     var node = null;
+                                    var is_true_output=true;
+                                    var old_nodes_output=this.props.app.getDiagramEngine().getDiagramModel().serializeDiagram().nodes;
+                                    
                                     if (data.name === "inp_layer") {
                                       node = new DefaultNodeModel("Input", "rgb(0,102,255)");
                                       node.addPort(new DefaultPortModel(false, "out-1", "out"));
@@ -476,13 +479,20 @@ class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState> {
                                         wight: 0.5
                                       }
                                     } else if (data.name === "out_layer") {
-
+                                      for(var i =0;i<old_nodes_output.length;i++){
+                                        if (old_nodes_output[i].extras.name==="Output Node"){
+                                          window.alert("There is already one output Node");
+                                          is_true_output=false;
+                                          break;
+                                        }
+                                      }
+                                      if(is_true_output){
                                       node = new DefaultNodeModel("Output", "rgb(90,102,255)");
                                       node.addPort(new DefaultPortModel(true, "in-1", "In"));
                                       node.extras = {
                                         name: "Output Node",
                                         wight: 0.5
-                                      }
+                                      }}
                                     }
                                     else {
                                       node = new DefaultNodeModel("Dense", "rgb(0,192,255)");
@@ -493,6 +503,7 @@ class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState> {
                                         wight: 0.5
                                       }
                                     }
+                                    if(node != null){
                                     var points = this.props.app.getDiagramEngine().getRelativeMousePoint(event);
                                     node.x = points.x;
                                     node.y = points.y;
@@ -501,7 +512,7 @@ class BodyWidget extends React.Component<BodyWidgetProps, BodyWidgetState> {
                                       .getDiagramModel()
                                       .addNode(node);
                                     this.forceUpdate();
-                                  }
+                                  }}
                                 }
           						onDragOver = {
                           event => {


### PR DESCRIPTION
Pulling two output nodes give a window alert box .
solves #114 
![output com-video-to-gif (1)](https://user-images.githubusercontent.com/45288400/76686216-db832800-663f-11ea-8e1f-9e225d9394ab.gif)

@orionpax00 @keshan @ivantha @sumedhe Please have a look and review this :)